### PR TITLE
ImageFlux::Option#to_query と ImageFlux::Origin#image_url に、複数の変換パラメータを区切るカンマをエスケープするオプションを追加

### DIFF
--- a/lib/image_flux/option.rb
+++ b/lib/image_flux/option.rb
@@ -112,7 +112,7 @@ class ImageFlux::Option
     @values[prefix_attr]
   end
 
-  def to_query(ignore_default: true)
+  def to_query(escape_comma: false)
     errors = []
     queries = @values.to_a.map do |pair|
       attribute = pair.first
@@ -122,6 +122,7 @@ class ImageFlux::Option
     end
     raise ImageFlux::InvalidOptionError, errors.join(', ') unless errors.length.zero?
 
-    queries.reject(&:nil?).join(',')
+    query_separator = escape_comma ? '%2C' : ','
+    queries.reject(&:nil?).join(query_separator)
   end
 end

--- a/lib/image_flux/origin.rb
+++ b/lib/image_flux/origin.rb
@@ -18,17 +18,17 @@ class ImageFlux::Origin
     @base_url ||= URI("#{@scheme}://#{@domain}/")
   end
 
-  def image_url(path, options = {})
+  def image_url(path, options = {}, escape_comma = false)
     path = "/#{path}" unless path.start_with?('/')
 
     options = options.merge(sig: sign(path)) if @signing_secret
     opt = ImageFlux::Option.new(options)
 
     path = "#{opt.prefix_path}#{path}" if opt.prefix_path
-    query = opt.to_query
+    query = opt.to_query(escape_comma: escape_comma)
 
     url = base_url.dup
-    url.path = query.length.zero? ? path : "/c/#{opt.to_query}#{path}"
+    url.path = query.length.zero? ? path : "/c/#{query}#{path}"
 
     url
   end

--- a/spec/image_flux/option_spec.rb
+++ b/spec/image_flux/option_spec.rb
@@ -9,5 +9,11 @@ RSpec.describe ImageFlux::Option do
     subject(:to_query) { option.to_query }
 
     it { is_expected.to eq('w=100,o=0,f=png,a=2,ig=1,ic=0:0:100:100') }
+
+    context 'with escaping comma option' do
+      subject(:to_query) { option.to_query(escape_comma: true) }
+
+      it { is_expected.to eq('w=100%2Co=0%2Cf=png%2Ca=2%2Cig=1%2Cic=0:0:100:100') }
+    end
   end
 end

--- a/spec/image_flux/origin_spec.rb
+++ b/spec/image_flux/origin_spec.rb
@@ -27,5 +27,12 @@ RSpec.describe ImageFlux::Origin do
 
       it { expect(image_url.path).to eq('/c/w=100/small/image.jpg') }
     end
+
+    context 'with escaping comma option' do
+      let(:options) { { w: 100, h: 100 } }
+      subject(:image_url) { origin.image_url(path, options, escape_comma = true) }
+
+      it { expect(image_url.path).to eq('/c/w=100%2Ch=100/image.jpg') }
+    end
   end
 end


### PR DESCRIPTION
ImagefluxのリクエストURLで、複数の変換パラメータを区切る`,`はエスケープ可能だが、(下記参照)
現状`,`をエスケープするオプションが存在しない。

そこで`ImageFlux::Option#to_query`, `ImageFlux::Origin#image_url`に`,`をエスケープするオプションを作成した。

> このときのリクエストURLは次のようになります。
> ```
> https://demo.imageflux.jp/w=400,l=(w=300%2fimages%2f1.png),f=webp:auto/bridge.jpg
> ```
> HTML中でsrcset属性のように、カンマ区切りのリストを利用しておりURL内にカンマを含むことができない場合、パーセントエンコードした%2C(または%2c)に置き換えられます。
> ```
> https://demo.imageflux.jp/w=400%2cl=(w=300%2fimages%2f1.png)%2cf=webp:auto/bridge.jpg
> ```

https://console.imageflux.jp/docs/image/conversion-parameters